### PR TITLE
[centralsystem] Add interfaces to get the IP address of a connected Charge Point

### DIFF
--- a/src/centralsystem/chargepoint/ChargePointProxy.cpp
+++ b/src/centralsystem/chargepoint/ChargePointProxy.cpp
@@ -77,6 +77,12 @@ ChargePointProxy::~ChargePointProxy() { }
 
 // ICentralSystem::IChargePoint interface
 
+/** @copydoc const std::string& ICentralSystem::IChargePoint::ipAddress() const */
+const std::string& ChargePointProxy::ipAddress() const
+{
+    return m_rpc->ipAddress();
+}
+
 /** @copydoc void ICentralSystem::IChargePoint::setTimeout(std::chrono::milliseconds) */
 void ChargePointProxy::setTimeout(std::chrono::milliseconds timeout)
 {

--- a/src/centralsystem/chargepoint/ChargePointProxy.h
+++ b/src/centralsystem/chargepoint/ChargePointProxy.h
@@ -59,6 +59,9 @@ class ChargePointProxy : public ICentralSystem::IChargePoint, public ocpp::rpc::
     /** @copydoc ICentralSystem&& ICentralSystem::IChargePoint::centralSystem() */
     ICentralSystem& centralSystem() override { return m_central_system; }
 
+    /** @copydoc const std::string& ICentralSystem::IChargePoint::ipAddress() const */
+    const std::string& ipAddress() const override;
+
     /** @copydoc const std::string& ICentralSystem::IChargePoint::identifier() const */
     const std::string& identifier() const override { return m_identifier; }
 

--- a/src/centralsystem/interface/ICentralSystem.h
+++ b/src/centralsystem/interface/ICentralSystem.h
@@ -126,6 +126,12 @@ class ICentralSystem
         virtual ICentralSystem& centralSystem() = 0;
 
         /**
+         * @brief Get the IP address of the charge point
+         * @return IP address of the charge point
+         */
+        virtual const std::string& ipAddress() const = 0;
+
+        /**
          * @brief Get the charge point identifier
          * @return charge point identifier
          */

--- a/src/rpc/RpcServer.cpp
+++ b/src/rpc/RpcServer.cpp
@@ -133,6 +133,12 @@ RpcServer::Client::~Client()
     RpcBase::stop();
 }
 
+/** @brief Get the IP address of the client */
+const std::string& RpcServer::Client::ipAddress() const
+{
+    return m_websocket->ipAddress();
+}
+
 /** @brief Disconnect the client */
 bool RpcServer::Client::disconnect(bool notify_disconnected)
 {

--- a/src/rpc/RpcServer.h
+++ b/src/rpc/RpcServer.h
@@ -112,6 +112,12 @@ class RpcServer : public ocpp::websockets::IWebsocketServer::IListener
         virtual ~Client();
 
         /**
+         * @brief Get the IP address of the client
+         * @return IP address of the client
+         */
+        const std::string& ipAddress() const;
+
+        /**
          * @brief Disconnect the client
          * @param notify_disconnected Indicate if the listener must be notified when disconnected
          * @return true if the client has been disconnected, false otherwise

--- a/src/websockets/IWebsocketServer.h
+++ b/src/websockets/IWebsocketServer.h
@@ -103,6 +103,12 @@ class IWebsocketServer
         virtual ~IClient() { }
 
         /**
+         * @brief Get the IP address of the client
+         * @return IP address of the client
+         */
+        virtual const std::string& ipAddress() const = 0;
+
+        /**
          * @brief Disconnect the client
          * @param notify_disconnected Indicate if the listener must be notified owhen disconnected
          * @return true if the disconnection is successfull, false otherwise

--- a/src/websockets/libwebsockets/LibWebsocketServer.cpp
+++ b/src/websockets/libwebsockets/LibWebsocketServer.cpp
@@ -365,8 +365,12 @@ int LibWebsocketServer::eventCallback(struct lws* wsi, enum lws_callback_reasons
 
         case LWS_CALLBACK_ESTABLISHED:
         {
+            // Get client IP address
+            char ip_address[64];
+            lws_get_peer_simple(wsi, ip_address, sizeof(ip_address));
+
             // Instanciate a new client
-            std::shared_ptr<IClient> client(new Client(wsi));
+            std::shared_ptr<IClient> client(new Client(wsi, ip_address));
             server->m_clients[wsi] = client;
 
             // Notify connection
@@ -465,11 +469,20 @@ int LibWebsocketServer::eventCallback(struct lws* wsi, enum lws_callback_reasons
 }
 
 /** @brief Constructor */
-LibWebsocketServer::Client::Client(struct lws* wsi) : m_wsi(wsi), m_connected(true), m_listener(nullptr), m_send_msgs() { }
+LibWebsocketServer::Client::Client(struct lws* wsi, const char* ip_address)
+    : m_wsi(wsi), m_ip_address(ip_address), m_connected(true), m_listener(nullptr), m_send_msgs()
+{
+}
 /** @brief Destructor */
 LibWebsocketServer::Client::~Client()
 {
     disconnect(true);
+}
+
+/** @copydoc const std::string& IClient::ipAddress(bool) const */
+const std::string& LibWebsocketServer::Client::ipAddress() const
+{
+    return m_ip_address;
 }
 
 /** @copydoc bool IClient::disconnect(bool) */

--- a/src/websockets/libwebsockets/LibWebsocketServer.h
+++ b/src/websockets/libwebsockets/LibWebsocketServer.h
@@ -89,10 +89,14 @@ class LibWebsocketServer : public IWebsocketServer
         /**
          * @brief Constructor
          * @param wsi Client socket
+         * @param ip_address IP address
         */
-        Client(struct lws* wsi);
+        Client(struct lws* wsi, const char* ip_address);
         /** @brief Destructor */
         virtual ~Client();
+
+        /** @copydoc const std::string& IClient::ipAddress(bool) const */
+        const std::string& ipAddress() const override;
 
         /** @copydoc bool IClient::disconnect(bool) */
         bool disconnect(bool notify_disconnected) override;
@@ -109,6 +113,8 @@ class LibWebsocketServer : public IWebsocketServer
       private:
         /** @brief Client socket */
         struct lws* m_wsi;
+        /** @brief IP address */
+        const std::string m_ip_address;
         /** @brief Connection status */
         bool m_connected;
         /** @brief Listener */


### PR DESCRIPTION
Now the IP address of a connected charge point can be retrieved through  the CentralSytem::IChargePoint interface.