### PR TITLE
Dev/add callerror support

### DIFF
--- a/src/messages/GenericMessageSender.h
+++ b/src/messages/GenericMessageSender.h
@@ -97,14 +97,14 @@ class GenericMessageSender
                 if (!request_fifo || request_fifo->empty())
                 {
                     // Execute call
-                    rapidjson::Document resp;
-                    resp.Parse("{}");
-                    if (m_rpc.call(action, payload, resp, m_timeout))
+                    rapidjson::Document rpc_frame;
+                    rapidjson::Value    resp;
+                    if (m_rpc.call(action, payload, rpc_frame, resp, m_timeout))
                     {
                         // Convert response
                         const char* error_code = nullptr;
                         std::string error_message;
-                        resp_converter->setAllocator(&resp.GetAllocator());
+                        resp_converter->setAllocator(&rpc_frame.GetAllocator());
                         if (resp_converter->fromJson(resp, response, error_code, error_message))
                         {
                             ret = CallResult::Ok;
@@ -149,14 +149,14 @@ class GenericMessageSender
         if (resp_converter)
         {
             // Execute call
-            rapidjson::Document resp;
-            resp.Parse("{}");
-            if (m_rpc.call(action, request, resp, m_timeout))
+            rapidjson::Document rpc_frame;
+            rapidjson::Value    resp;
+            if (m_rpc.call(action, request, rpc_frame, resp, m_timeout))
             {
                 // Convert response
                 const char* error_code = nullptr;
                 std::string error_message;
-                resp_converter->setAllocator(&resp.GetAllocator());
+                resp_converter->setAllocator(&rpc_frame.GetAllocator());
                 if (resp_converter->fromJson(resp, response, error_code, error_message))
                 {
                     ret = CallResult::Ok;

--- a/src/rpc/IRpc.h
+++ b/src/rpc/IRpc.h
@@ -52,6 +52,8 @@ class IRpc
      * @param payload JSON payload for the action
      * @param rpc_frame Full JSON response received
      * @param response JSON response received
+     * @param error Error code (empty if no error)
+     * @param message Error message (empty if no error)
      * @param timeout Response timeout
      * @return true if a response has been received, false otherwise
      */
@@ -59,6 +61,8 @@ class IRpc
                       const rapidjson::Document& payload,
                       rapidjson::Document&       rpc_frame,
                       rapidjson::Value&          response,
+                      std::string&               error,
+                      std::string&               message,
                       std::chrono::milliseconds  timeout = std::chrono::seconds(2)) = 0;
 
     /**

--- a/src/rpc/IRpc.h
+++ b/src/rpc/IRpc.h
@@ -50,13 +50,15 @@ class IRpc
      * @brief Call a remote action and wait for its response
      * @param action Remote action
      * @param payload JSON payload for the action
+     * @param rpc_frame Full JSON response received
      * @param response JSON response received
      * @param timeout Response timeout
      * @return true if a response has been received, false otherwise
      */
     virtual bool call(const std::string&         action,
                       const rapidjson::Document& payload,
-                      rapidjson::Document&       response,
+                      rapidjson::Document&       rpc_frame,
+                      rapidjson::Value&          response,
                       std::chrono::milliseconds  timeout = std::chrono::seconds(2)) = 0;
 
     /**

--- a/src/rpc/RpcBase.cpp
+++ b/src/rpc/RpcBase.cpp
@@ -45,10 +45,11 @@ RpcBase::~RpcBase()
     stop();
 }
 
-/** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, std::chrono::milliseconds) */
+/** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, rapidjson::Value&, std::chrono::milliseconds) */
 bool RpcBase::call(const std::string&         action,
                    const rapidjson::Document& payload,
-                   rapidjson::Document&       response,
+                   rapidjson::Document&       rpc_frame,
+                   rapidjson::Value&          response,
                    std::chrono::milliseconds  timeout)
 {
     bool ret = false;
@@ -110,7 +111,8 @@ bool RpcBase::call(const std::string&         action,
             // Extract response
             if (rpc_message)
             {
-                response.CopyFrom(rpc_message->payload, response.GetAllocator());
+                rpc_frame.Swap(rpc_message->rpc_frame);
+                response.Swap(rpc_message->payload);
                 delete rpc_message;
             }
             else
@@ -233,14 +235,14 @@ void RpcBase::processReceivedData(const void* data, size_t size)
                     switch (msg_type)
                     {
                         case MessageType::CALL:
-                            valid = decodeCall(unique_id, rpc_frame[2], rpc_frame[3]);
+                            valid = decodeCall(unique_id, rpc_frame, rpc_frame[2], rpc_frame[3]);
                             break;
                         case MessageType::CALLRESULT:
-                            valid = decodeCallResult(unique_id, rpc_frame[2]);
+                            valid = decodeCallResult(unique_id, rpc_frame, rpc_frame[2]);
                             break;
                         case MessageType::CALLERROR:
                         default:
-                            valid = decodeCallError(unique_id, rpc_frame[2], rpc_frame[3], rpc_frame[4]);
+                            valid = decodeCallError(unique_id, rpc_frame, rpc_frame[2], rpc_frame[3], rpc_frame[4]);
                             break;
                     }
                     if (!valid)
@@ -283,7 +285,10 @@ bool RpcBase::send(const std::string& msg)
 }
 
 /** @brief Decode a CALL message */
-bool RpcBase::decodeCall(const std::string& unique_id, const rapidjson::Value& action, const rapidjson::Value& payload)
+bool RpcBase::decodeCall(const std::string&      unique_id,
+                         rapidjson::Document&    rpc_frame,
+                         const rapidjson::Value& action,
+                         rapidjson::Value&       payload)
 {
     bool ret = false;
 
@@ -291,7 +296,7 @@ bool RpcBase::decodeCall(const std::string& unique_id, const rapidjson::Value& a
     if (action.IsString() && payload.IsObject())
     {
         // Add request to the queue
-        RpcMessage* msg = new RpcMessage(unique_id, action.GetString(), payload);
+        RpcMessage* msg = new RpcMessage(unique_id, action.GetString(), rpc_frame, payload);
         m_requests_queue.push(msg);
 
         ret = true;
@@ -301,7 +306,7 @@ bool RpcBase::decodeCall(const std::string& unique_id, const rapidjson::Value& a
 }
 
 /** @brief Decode a CALLRESULT message */
-bool RpcBase::decodeCallResult(const std::string& unique_id, const rapidjson::Value& payload)
+bool RpcBase::decodeCallResult(const std::string& unique_id, rapidjson::Document& rpc_frame, rapidjson::Value& payload)
 {
     bool ret = false;
 
@@ -309,7 +314,7 @@ bool RpcBase::decodeCallResult(const std::string& unique_id, const rapidjson::Va
     if (payload.IsObject())
     {
         // Add result to the queue
-        RpcMessage* msg = new RpcMessage(unique_id, payload);
+        RpcMessage* msg = new RpcMessage(unique_id, rpc_frame, payload);
         m_results_queue.push(msg);
 
         ret = true;
@@ -320,6 +325,7 @@ bool RpcBase::decodeCallResult(const std::string& unique_id, const rapidjson::Va
 
 /** @brief Decode a CALLERROR message */
 bool RpcBase::decodeCallError(const std::string&      unique_id,
+                              rapidjson::Document&    rpc_frame,
                               const rapidjson::Value& error,
                               const rapidjson::Value& message,
                               const rapidjson::Value& payload)
@@ -330,6 +336,7 @@ bool RpcBase::decodeCallError(const std::string&      unique_id,
     if (error.IsString() && message.IsString() && payload.IsObject())
     {
         (void)unique_id;
+        (void)rpc_frame;
         ret = true;
     }
 

--- a/src/rpc/RpcBase.h
+++ b/src/rpc/RpcBase.h
@@ -44,10 +44,11 @@ class RpcBase : public IRpc
 
     // IRpc interface
 
-    /** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, std::chrono::milliseconds) */
+    /** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, rapidjson::Value&, std::chrono::milliseconds) */
     bool call(const std::string&         action,
               const rapidjson::Document& payload,
-              rapidjson::Document&       response,
+              rapidjson::Document&       rpc_frame,
+              rapidjson::Value&          response,
               std::chrono::milliseconds  timeout = std::chrono::seconds(2)) override;
 
     /** @copydoc void IRpc::registerListener(IListener&) */
@@ -86,18 +87,20 @@ class RpcBase : public IRpc
     /** @brief RPC message */
     struct RpcMessage
     {
-        RpcMessage(const std::string& _unique_id, const char* _action, const rapidjson::Value& _payload)
-            : unique_id(_unique_id), action(_action), payload()
+        RpcMessage(const std::string& _unique_id, const char* _action, rapidjson::Document& _rpc_frame, rapidjson::Value& _payload)
+            : unique_id(_unique_id), action(_action), rpc_frame(std::move(_rpc_frame)), payload()
         {
-            payload.CopyFrom(_payload, payload.GetAllocator());
+            payload.Swap(_payload);
         }
-        RpcMessage(const std::string& _unique_id, const rapidjson::Value& _payload) : unique_id(_unique_id), action(), payload()
+        RpcMessage(const std::string& _unique_id, rapidjson::Document& _rpc_frame, rapidjson::Value& _payload)
+            : unique_id(_unique_id), action(), rpc_frame(std::move(_rpc_frame)), payload()
         {
-            payload.CopyFrom(_payload, payload.GetAllocator());
+            payload.Swap(_payload);
         }
         const std::string   unique_id;
         const std::string   action;
-        rapidjson::Document payload;
+        rapidjson::Document rpc_frame;
+        rapidjson::Value    payload;
     };
 
     /** @brief RPC listener */
@@ -119,13 +122,17 @@ class RpcBase : public IRpc
     bool send(const std::string& msg);
 
     /** @brief Decode a CALL message */
-    bool decodeCall(const std::string& unique_id, const rapidjson::Value& action, const rapidjson::Value& payload);
+    bool decodeCall(const std::string&      unique_id,
+                    rapidjson::Document&    rpc_frame,
+                    const rapidjson::Value& action,
+                    rapidjson::Value&       payload);
 
     /** @brief Decode a CALLRESULT message */
-    bool decodeCallResult(const std::string& unique_id, const rapidjson::Value& payload);
+    bool decodeCallResult(const std::string& unique_id, rapidjson::Document& rpc_frame, rapidjson::Value& payload);
 
     /** @brief Decode a CALLERROR message */
     bool decodeCallError(const std::string&      unique_id,
+                         rapidjson::Document&    rpc_frame,
                          const rapidjson::Value& error,
                          const rapidjson::Value& message,
                          const rapidjson::Value& payload);

--- a/tests/rpc/test_rpc.cpp
+++ b/tests/rpc/test_rpc.cpp
@@ -166,7 +166,7 @@ static constexpr const char* EXPECTED_CALL_MESSAGE_1       = "[2, \"1\", \"Heart
 static constexpr const char* EXPECTED_CALL_MESSAGE_2       = "[2, \"2\", \"Heartbeat\", {\"id\":4}]";
 static constexpr const char* EXPECTED_CALLRESULT_MESSAGE_1 = "[3, \"1\", {\"name\":\"bob\"}]";
 static constexpr const char* EXPECTED_CALLRESULT_MESSAGE_2 = "[3, \"2\", {\"name\":\"bob\"}]";
-static constexpr const char* EXPECTED_CALLERROR_MESSAGE_1  = "[4, \"1\", \"NotImplemented\", \"This is an error!\", {}]";
+static constexpr const char* EXPECTED_CALLERROR_MESSAGE_0  = "[4, \"0\", \"NotImplemented\", \"This is an error!\", {}]";
 
 TEST_SUITE("CALL messages")
 {
@@ -184,14 +184,16 @@ TEST_SUITE("CALL messages")
 
         rapidjson::Document                        rpc_frame;
         rapidjson::Value                           response;
+        std::string                                error;
+        std::string                                message;
         rapidjson::StringBuffer                    buffer;
         rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, std::chrono::milliseconds(0)));
+        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(0)));
         CHECK(websocket.sendCalled());
         CHECK_EQ(strcmp(reinterpret_cast<const char*>(websocket.sentData()), EXPECTED_CALL_MESSAGE_0), 0);
 
-        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, std::chrono::milliseconds(0)));
+        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(0)));
         CHECK_EQ(strcmp(reinterpret_cast<const char*>(websocket.sentData()), EXPECTED_CALL_MESSAGE_1), 0);
 
         std::thread response_thread(
@@ -200,10 +202,38 @@ TEST_SUITE("CALL messages")
                 std::this_thread::sleep_for(std::chrono::milliseconds(25u));
                 websocket.notifyDataReceived(EXPECTED_CALLRESULT_MESSAGE_2, strlen(EXPECTED_CALLRESULT_MESSAGE_2));
             });
-        CHECK(client.call(ACTION, payload, rpc_frame, response, std::chrono::milliseconds(50)));
+        CHECK(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(50)));
         CHECK_EQ(strcmp(reinterpret_cast<const char*>(websocket.sentData()), EXPECTED_CALL_MESSAGE_2), 0);
         response.Accept(writer);
         CHECK_EQ(strcmp(buffer.GetString(), CALLRESULT_PAYLOAD), 0);
+        response_thread.join();
+    }
+
+    TEST_CASE("Call error")
+    {
+        RpcClientListener   listener;
+        WebsocketClientStub websocket;
+        RpcClient           client(websocket, WS_PROTOCOL);
+        client.registerListener(listener);
+        client.registerClientListener(listener);
+        websocket.setConnected();
+
+        rapidjson::Document payload;
+        rapidjson::Document rpc_frame;
+        rapidjson::Value    response;
+        std::string         error;
+        std::string         message;
+
+        std::thread response_thread(
+            [&websocket]
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(25u));
+                websocket.notifyDataReceived(EXPECTED_CALLERROR_MESSAGE_0, strlen(EXPECTED_CALLERROR_MESSAGE_0));
+            });
+        CHECK(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(50)));
+        CHECK_EQ(error, "NotImplemented");
+        CHECK_EQ(message, "This is an error!");
+        CHECK(response.IsObject());
         response_thread.join();
     }
 
@@ -219,16 +249,18 @@ TEST_SUITE("CALL messages")
         rapidjson::Document payload;
         rapidjson::Document rpc_frame;
         rapidjson::Value    response;
+        std::string         error;
+        std::string         message;
 
         auto start = std::chrono::steady_clock::now();
-        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, std::chrono::milliseconds(0)));
+        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(0)));
         auto                          end  = std::chrono::steady_clock::now();
         std::chrono::duration<double> diff = end - start;
         CHECK_LT(diff, std::chrono::milliseconds(5u));
         CHECK(websocket.sendCalled());
 
         start = std::chrono::steady_clock::now();
-        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, std::chrono::milliseconds(100)));
+        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(100)));
         end  = std::chrono::steady_clock::now();
         diff = end - start;
         CHECK_GT(diff, std::chrono::milliseconds(99u));
@@ -240,7 +272,7 @@ TEST_SUITE("CALL messages")
                 std::this_thread::sleep_for(std::chrono::milliseconds(100u));
                 websocket.notifyDataReceived(EXPECTED_CALLRESULT_MESSAGE_2, strlen(EXPECTED_CALLRESULT_MESSAGE_2));
             });
-        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, std::chrono::milliseconds(50)));
+        CHECK_FALSE(client.call(ACTION, payload, rpc_frame, response, error, message, std::chrono::milliseconds(50)));
         response_thread.join();
     }
 
@@ -277,11 +309,11 @@ TEST_SUITE("CALL messages")
         listener.received_error = true;
         listener.error_code     = IRpc::RPC_ERROR_NOT_IMPLEMENTED;
         listener.error_message  = CALLERROR_PAYLOAD;
-        websocket.notifyDataReceived(EXPECTED_CALL_MESSAGE_1, strlen(EXPECTED_CALL_MESSAGE_1));
+        websocket.notifyDataReceived(EXPECTED_CALL_MESSAGE_0, strlen(EXPECTED_CALL_MESSAGE_0));
         std::this_thread::sleep_for(std::chrono::milliseconds(50u));
         CHECK_EQ(listener.action, ACTION);
         CHECK_EQ(listener.payload, CALL_PAYLOAD);
         CHECK(websocket.sendCalled());
-        CHECK_EQ(strcmp(reinterpret_cast<const char*>(websocket.sentData()), EXPECTED_CALLERROR_MESSAGE_1), 0);
+        CHECK_EQ(strcmp(reinterpret_cast<const char*>(websocket.sentData()), EXPECTED_CALLERROR_MESSAGE_0), 0);
     }
 }

--- a/tests/stubs/RpcStub.cpp
+++ b/tests/stubs/RpcStub.cpp
@@ -23,15 +23,21 @@ namespace ocpp
 namespace rpc
 {
 /** @brief Constructor */
-RpcStub::RpcStub() : m_connected(false), m_listener(nullptr), m_spy(nullptr), m_call_will_fail(false), m_response() { }
+RpcStub::RpcStub()
+    : m_connected(false), m_listener(nullptr), m_spy(nullptr), m_call_will_fail(false), m_response(), m_error(), m_message(), m_calls()
+{
+}
 /** @brief Destructor */
 RpcStub::~RpcStub() { }
 
-/** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, rapidjson::Value&, std::chrono::milliseconds) */
+/** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, rapidjson::Value&,
+                             std::string&, std::string&, std::chrono::milliseconds) */
 bool RpcStub::call(const std::string&         action,
                    const rapidjson::Document& payload,
                    rapidjson::Document&       rpc_frame,
                    rapidjson::Value&          response,
+                   std::string&               error,
+                   std::string&               message,
                    std::chrono::milliseconds  timeout)
 {
     (void)timeout;
@@ -44,6 +50,8 @@ bool RpcStub::call(const std::string&         action,
         m_calls.emplace_back(action, doc);
         rpc_frame.CopyFrom(m_response, rpc_frame.GetAllocator());
         response.CopyFrom(m_response, rpc_frame.GetAllocator());
+        error   = m_error;
+        message = m_message;
 
         ret = !m_call_will_fail;
     }

--- a/tests/stubs/RpcStub.cpp
+++ b/tests/stubs/RpcStub.cpp
@@ -27,10 +27,11 @@ RpcStub::RpcStub() : m_connected(false), m_listener(nullptr), m_spy(nullptr), m_
 /** @brief Destructor */
 RpcStub::~RpcStub() { }
 
-/** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, std::chrono::milliseconds) */
+/** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, rapidjson::Value&, std::chrono::milliseconds) */
 bool RpcStub::call(const std::string&         action,
                    const rapidjson::Document& payload,
-                   rapidjson::Document&       response,
+                   rapidjson::Document&       rpc_frame,
+                   rapidjson::Value&          response,
                    std::chrono::milliseconds  timeout)
 {
     (void)timeout;
@@ -41,7 +42,8 @@ bool RpcStub::call(const std::string&         action,
         rapidjson::Document* doc = new rapidjson::Document();
         doc->CopyFrom(payload, doc->GetAllocator());
         m_calls.emplace_back(action, doc);
-        response.CopyFrom(m_response, response.GetAllocator());
+        rpc_frame.CopyFrom(m_response, rpc_frame.GetAllocator());
+        response.CopyFrom(m_response, rpc_frame.GetAllocator());
 
         ret = !m_call_will_fail;
     }

--- a/tests/stubs/RpcStub.h
+++ b/tests/stubs/RpcStub.h
@@ -41,10 +41,11 @@ class RpcStub : public IRpc
     /** @copydoc bool IRpc::isConnected() */
     bool isConnected() const override { return m_connected; }
 
-    /** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, std::chrono::milliseconds) */
+    /** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&,rapidjson::Value&, std::chrono::milliseconds) */
     bool call(const std::string&         action,
               const rapidjson::Document& payload,
-              rapidjson::Document&       response,
+              rapidjson::Document&       rpc_frame,
+              rapidjson::Value&          response,
               std::chrono::milliseconds  timeout) override;
 
     /** @copydoc void IRpc::registerListener(IListener&) */

--- a/tests/stubs/RpcStub.h
+++ b/tests/stubs/RpcStub.h
@@ -41,11 +41,14 @@ class RpcStub : public IRpc
     /** @copydoc bool IRpc::isConnected() */
     bool isConnected() const override { return m_connected; }
 
-    /** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&,rapidjson::Value&, std::chrono::milliseconds) */
+    /** @copydoc bool IRpc::call(const std::string&, const rapidjson::Document&, rapidjson::Document&, rapidjson::Value&,
+     *                           std::string&, std::string&, std::chrono::milliseconds) */
     bool call(const std::string&         action,
               const rapidjson::Document& payload,
               rapidjson::Document&       rpc_frame,
               rapidjson::Value&          response,
+              std::string&               error,
+              std::string&               message,
               std::chrono::milliseconds  timeout) override;
 
     /** @copydoc void IRpc::registerListener(IListener&) */
@@ -62,6 +65,10 @@ class RpcStub : public IRpc
     void setCallWilFail(bool call_will_fail) { m_call_will_fail = call_will_fail; }
     /** @brief Set the next response */
     void setResponse(const rapidjson::Document& response);
+    /** @brief Set the next error */
+    void setError(const std::string& error) { m_error = error; }
+    /** @brief Set the next error messae */
+    void setMessage(const std::string& message) { m_message = message; }
     /** @brief Get the listener */
     IRpc::IListener* getListener() { return m_listener; }
     /** @brief Get the spy */
@@ -82,6 +89,10 @@ class RpcStub : public IRpc
     bool m_call_will_fail;
     /** @brief Next response */
     rapidjson::Document m_response;
+    /** @brief Next error */
+    std::string m_error;
+    /** @brief Next error message */
+    std::string m_message;
     /** @brief Calls */
     std::vector<std::pair<std::string, std::unique_ptr<rapidjson::Document>>> m_calls;
 };


### PR DESCRIPTION
Optimize memory when receiving call results by avoiding unnecessary copies.
Add error code and error message as return parameters to the RPC call function to allow CallError responses handling.