### PR TITLE
Fix/multithreading issues

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,4 +66,4 @@ jobs:
        make clang-native
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/src/chargepoint/reservation/ReservationManager.cpp
+++ b/src/chargepoint/reservation/ReservationManager.cpp
@@ -311,7 +311,7 @@ void ReservationManager::checkExpiries()
         if ((connector->status == ChargePointStatus::Reserved) && (connector->reservation_expiry_date <= now))
         {
             // End reservation
-            endReservation(connector->id, false);
+            m_worker_pool.run<void>(std::bind(&ReservationManager::endReservation, this, connector->id, false));
         }
     }
 }

--- a/src/rpc/RpcClient.h
+++ b/src/rpc/RpcClient.h
@@ -115,6 +115,8 @@ class RpcClient : public RpcBase, public ocpp::websockets::IWebsocketClient::ILi
     IListener* m_listener;
     /** @brief Started state */
     bool m_started;
+    /** @brief Mutex for concurrent stop access */
+    std::mutex m_stop_mutex;
 };
 
 } // namespace rpc

--- a/src/websockets/libwebsockets/LibWebsocketClient.cpp
+++ b/src/websockets/libwebsockets/LibWebsocketClient.cpp
@@ -18,6 +18,7 @@ along with OpenOCPP. If not, see <http://www.gnu.org/licenses/>.
 
 #include "LibWebsocketClient.h"
 
+#include <csignal>
 #include <cstdint>
 #include <functional>
 #include <iostream>
@@ -233,6 +234,12 @@ void LibWebsocketClient::process()
 {
     // Save this pointer for further callbacks
     client = this;
+
+    // Mask SIG_PIPE signal
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGPIPE);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
 
     // Event loop
     int ret = 0;

--- a/src/websockets/libwebsockets/LibWebsocketServer.cpp
+++ b/src/websockets/libwebsockets/LibWebsocketServer.cpp
@@ -18,6 +18,7 @@ along with OpenOCPP. If not, see <http://www.gnu.org/licenses/>.
 
 #include "LibWebsocketServer.h"
 
+#include <csignal>
 #include <cstdint>
 #include <functional>
 #include <iostream>
@@ -221,6 +222,12 @@ void LibWebsocketServer::process()
 {
     // Save this pointer for further callbacks
     server = this;
+
+    // Mask SIG_PIPE signal
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGPIPE);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
 
     // Event loop
     int ret = 0;


### PR DESCRIPTION
[websocket] Mask uncaught SIGPIPE signals since error handling is already done through return values
[rpc - client] Add mutex for stop() method since it can be called concurrently when used in local controller
[chargepoint] Use worker thread pool when timer callbacks needs to send messages => allow no to block the timer thread

