### PR TITLE
reject ChangeConfiguration for interval keys with negative value

### DIFF
--- a/examples/common/config/OcppConfig.cpp
+++ b/examples/common/config/OcppConfig.cpp
@@ -197,21 +197,34 @@ ocpp::types::ConfigurationStatus OcppConfig::setConfiguration(const std::string&
     {
         if ((it->second & PARAM_WRITE) != 0)
         {
-            if ((it->second & PARAM_OCPP) != 0)
+            std::size_t key_is_interval = key.find("Interval");
+            if (key_is_interval != std::string::npos)
             {
-                m_config.set(OCPP_PARAMS, key, value);
+                std::size_t value_is_negative = key.find("-");
+                if(value_is_negative)
+                {
+                    ret = ConfigurationStatus::Rejected;
+                }
             }
-            else
+
+            if(ret != ConfigurationStatus::Rejected)
             {
-                m_config.set(STACK_PARAMS, key, value);
-            }
-            if ((it->second & PARAM_REBOOT) != 0)
-            {
-                ret = ConfigurationStatus::RebootRequired;
-            }
-            else
-            {
-                ret = ConfigurationStatus::Accepted;
+                if ((it->second & PARAM_OCPP) != 0)
+                {
+                    m_config.set(OCPP_PARAMS, key, value);
+                }
+                else
+                {
+                    m_config.set(STACK_PARAMS, key, value);
+                }
+                if ((it->second & PARAM_REBOOT) != 0)
+                {
+                    ret = ConfigurationStatus::RebootRequired;
+                }
+                else
+                {
+                    ret = ConfigurationStatus::Accepted;
+                }
             }
         }
         else


### PR DESCRIPTION
according to  Test case document OCTT for OCPP 1.6 , page 64 Table 50. Test Case Id: 040_2 if ChangeConfiguration key related to time interval must reject negative value. in  Description of 9.1.34. WebSocketPingInterval in Open Charge Point Protocol 1.6 edition 2 FINAL, "Positive values are interpreted as number of seconds between pings. Negative values are not allowed. ChangeConfiguration is expected to return a REJECTED result."