### PR TITLE
fix logic error in handling charging profiles

### DIFF
--- a/src/chargepoint/smartcharging/SmartChargingManager.cpp
+++ b/src/chargepoint/smartcharging/SmartChargingManager.cpp
@@ -303,6 +303,7 @@ bool SmartChargingManager::handleMessage(const ocpp::messages::SetChargingProfil
                         }
                         else
                         {
+                            ret = false;
                             error_message = "Recurring profiles must have a start schedule and a duration";
                         }
                     }


### PR DESCRIPTION
The case `Recurring profiles must have a start schedule and a duration` wasn't treat as an error.