### PR TITLE
[x509] Add issuer name DER data to certificate class to allow issuer name hash computation

### DIFF
--- a/src/chargepoint/iso15118/Iso15118Manager.cpp
+++ b/src/chargepoint/iso15118/Iso15118Manager.cpp
@@ -453,7 +453,7 @@ void Iso15118Manager::fillHashInfo(const ocpp::x509::Certificate& certificate, o
     // Compute hashes with SHA-256 algorithm
     Sha2 sha256;
     info.hashAlgorithm = HashAlgorithmEnumType::SHA256;
-    sha256.compute(certificate.issuerString().c_str(), certificate.issuerString().size());
+    sha256.compute(certificate.issuerDer().data(), certificate.issuerDer().size());
     info.issuerNameHash.assign(sha256.resultString());
     sha256.compute(&certificate.publicKey()[0], certificate.publicKey().size());
     info.issuerKeyHash.assign(sha256.resultString());

--- a/src/chargepoint/security/SecurityManager.cpp
+++ b/src/chargepoint/security/SecurityManager.cpp
@@ -774,7 +774,7 @@ void SecurityManager::fillHashInfo(const ocpp::x509::Certificate& certificate, o
     // Compute hashes with SHA-256 algorithm
     Sha2 sha256;
     info.hashAlgorithm = HashAlgorithmEnumType::SHA256;
-    sha256.compute(certificate.issuerString().c_str(), certificate.issuerString().size());
+    sha256.compute(certificate.issuerDer().data(), certificate.issuerDer().size());
     info.issuerNameHash.assign(sha256.resultString());
     sha256.compute(&certificate.publicKey()[0], certificate.publicKey().size());
     info.issuerKeyHash.assign(sha256.resultString());

--- a/src/tools/x509/Certificate.cpp
+++ b/src/tools/x509/Certificate.cpp
@@ -22,6 +22,7 @@ along with OpenOCPP. If not, see <http://www.gnu.org/licenses/>.
 #include "openssl.h"
 #include "sign.h"
 
+#include <cstring>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
@@ -360,6 +361,14 @@ void Certificate::readInfos(Certificate& certificate)
         X509_NAME* issuer           = X509_get_issuer_name(cert);
         certificate.m_issuer_string = convertX509Name(issuer);
         parseSubjectString(issuer, certificate.m_issuer);
+        const unsigned char* issuer_der      = nullptr;
+        size_t               issuer_der_size = 0;
+        X509_NAME_get0_der(issuer, &issuer_der, &issuer_der_size);
+        if (issuer_der)
+        {
+            certificate.m_issuer_der.resize(issuer_der_size);
+            memcpy(certificate.m_issuer_der.data(), issuer_der, issuer_der_size);
+        }
         X509_NAME* subject           = X509_get_subject_name(cert);
         certificate.m_subject_string = convertX509Name(subject);
         parseSubjectString(subject, certificate.m_subject);

--- a/src/tools/x509/Certificate.h
+++ b/src/tools/x509/Certificate.h
@@ -168,6 +168,12 @@ class Certificate : public X509Document
     const std::string& issuerString() const { return m_issuer_string; }
 
     /**
+     * @brief Get the issuer raw data
+     * @return Issuer raw data
+     */
+    const std::vector<uint8_t>& issuerDer() const { return m_issuer_der; }
+
+    /**
      * @brief Get the issuer alternate names
      * @return Issuer alternate names
      */
@@ -199,6 +205,8 @@ class Certificate : public X509Document
     Subject m_issuer;
     /** @brief Issuer string */
     std::string m_issuer_string;
+    /** @brief Issuer raw data */
+    std::vector<uint8_t> m_issuer_der;
     /** @brief Indicate if it is a self-signed certificate */
     bool m_is_self_signed;
 


### PR DESCRIPTION
Fix #145 