### PR TITLE
fix:Improve the reservation logic.

### DIFF
--- a/src/chargepoint/reservation/ReservationManager.cpp
+++ b/src/chargepoint/reservation/ReservationManager.cpp
@@ -132,18 +132,26 @@ ocpp::types::AuthorizationStatus ReservationManager::isTransactionAllowed(unsign
                 Connector& charge_point = m_connectors.getChargePointConnector();
                 if (charge_point.status == ChargePointStatus::Reserved)
                 {
-                    // At least 1 connector must stay available
-                    unsigned int available_count = 0;
-                    for (const Connector* c : m_connectors.getConnectors())
-                    {
-                        if (c->status == ChargePointStatus::Available)
-                        {
-                            available_count++;
-                        }
-                    }
-                    if (available_count > 1)
+                    // Ensure that the module functions properly even when the gun is inserted first by the user.
+                    if (m_connectors.getConnector(connector_id)->status == ChargePointStatus::Preparing)
                     {
                         ret = AuthorizationStatus::Accepted;
+                    }
+                    else
+                    {
+                        // At least 1 connector must stay available
+                        unsigned int available_count = 0;
+                        for (const Connector* c : m_connectors.getConnectors())
+                        {
+                            if (c->status == ChargePointStatus::Available)
+                            {
+                                available_count++;
+                            }
+                        }
+                        if (available_count >= 1)
+                        {
+                            ret = AuthorizationStatus::Accepted;
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
There is an issue with the previous condition. For example, in a charging station with two connectors, if Connector 0 is already in a "Reserved" state and the user first inserts the gun into Connector 1, Connector 1 will transition to a "Preparing" state, and the available_count will be equal to 1. As a result, the condition of available_count > 1 cannot pass the validation, leading to a failed charging initiation.