### PR TITLE
[cmake] Add options to not build as a shared library, not build sqlite3 and not install doctest headers

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -8,11 +8,15 @@ endif()
 target_include_directories(rapidjson INTERFACE rapidjson/include)
 
 # Doctest is an header only on library
-add_library(doctest INTERFACE)
-target_include_directories(doctest INTERFACE doctest/doctest)
+if(${INSTALL_DOCTEST})
+    add_library(doctest INTERFACE)
+    target_include_directories(doctest INTERFACE doctest/doctest)
+endif()
 
 # SQLite 3
-add_subdirectory(sqlite3)
+if(${BUILD_SQLITE})
+    add_subdirectory(sqlite3)
+endif()
 
 # libwebsockets
 if(${BUILD_LWS_LIBRARY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,29 +89,32 @@ if(${BUILD_STATIC_LIBRARY})
 endif()
 
 # Open OCPP dynamic library
-add_library(open-ocpp-dynamic SHARED
-    src/version.cpp)
-target_link_libraries(open-ocpp-dynamic
-    centralsystem
-    chargepoint
-    localcontroller
-    config
-    database
-    messages
-    rpc
-    helpers
-    log
-    version
-    x509
-    json
-    ws
-    websockets
-)
-set_target_properties(open-ocpp-dynamic PROPERTIES
-    OUTPUT_NAME "open-ocpp"
-    VERSION ${PROJECT_VERSION}
-    SOVERSION ${PROJECT_VERSION_MAJOR}
-)
+if (${BUILD_SHARED_LIBRARY})
+    add_library(open-ocpp-dynamic SHARED
+        src/version.cpp)
+    target_link_libraries(open-ocpp-dynamic
+        centralsystem
+        chargepoint
+        localcontroller
+        config
+        database
+        messages
+        rpc
+        helpers
+        log
+        version
+        x509
+        json
+        ws
+        websockets
+    )
+    set_target_properties(open-ocpp-dynamic PROPERTIES
+        OUTPUT_NAME "open-ocpp"
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+    )
+    set(OPEN_OCPP_SHARED_TARGET open-ocpp-dynamic)
+endif()
 
 # Install commands
 include(GNUInstallDirs)
@@ -121,7 +124,7 @@ file(GLOB_RECURSE PUBLIC_HEADERS
 file(GLOB OCPP_SCHEMAS
      LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/schemas/*.json")
 
-install(TARGETS open-ocpp-dynamic ${OPEN_OCPP_STATIC_TARGET}
+install(TARGETS ${OPEN_OCPP_SHARED_TARGET} ${OPEN_OCPP_STATIC_TARGET}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -145,12 +148,14 @@ set(PKG_CONFIG_INCLUDEDIR   "\${prefix}/include/openocpp")
 set(PKG_CONFIG_LIBS         "-L\${libdir}")
 set(PKG_CONFIG_CFLAGS       "-I\${includedir}")
 
-set(LIB_NAME                "open-ocpp")
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/deploy/libopen-ocpp.pc.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/libopen-ocpp.pc"
-)
-install(FILES "${CMAKE_BINARY_DIR}/libopen-ocpp.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+if(${BUILD_SHARED_LIBRARY})
+    set(LIB_NAME                "open-ocpp")
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/deploy/libopen-ocpp.pc.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/libopen-ocpp.pc"
+    )
+    install(FILES "${CMAKE_BINARY_DIR}/libopen-ocpp.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()
 
 if(${BUILD_STATIC_LIBRARY})
     set(LIB_NAME                "open-ocpp_static")

--- a/CMakeLists_Options.txt
+++ b/CMakeLists_Options.txt
@@ -14,6 +14,9 @@ if(EXTERNAL_LOGGER)
     add_compile_definitions(EXTERNAL_LOGGER=1)
 endif()
 
+# Shared library
+option(BUILD_SHARED_LIBRARY         "Build Open OCPP as a shared library"                                   ON)
+
 # Static library
 option(BUILD_STATIC_LIBRARY         "Build Open OCPP as a static library"                                   ON)
 
@@ -25,6 +28,12 @@ option(BUILD_EXAMPLES               "Build examples"                            
 
 # Build the libwebsocket library along with the Open OCPP library
 option(BUILD_LWS_LIBRARY            "Build libwebsocket library"                                            ON)
+
+# Build the sqlite3 library along with the Open OCPP library
+option(BUILD_SQLITE                 "Build sqlite3 library"                                                 ON)
+
+# Install the Doctest header
+option(INSTALL_DOCTEST              "Install doctest headers"                                               ON)
 
 # Use only the CrtAllocator in Rapidjson, not the MemoryPoolAllocator
 option(USE_CRT_ALLOC_FOR_RAPIDJSON  "Use the CrtAllocator for Rapidjson instead of the MemoryPoolAllocator" OFF)


### PR DESCRIPTION
Hi, might be interesting to not force the install of the library as shared, especially as I use it as static.
Add option to not build sqlite3, as I don't want to overwrite the library already installed on my system.
Add option to not install doctest, since I don't need it on my system as well.
Could be useful to other people too.
I will probably add the option to not install rapidjson header on another PR.