### PR TITLE
handle empty id tag in stopTransaction

### DIFF
--- a/src/chargepoint/transaction/TransactionManager.cpp
+++ b/src/chargepoint/transaction/TransactionManager.cpp
@@ -219,7 +219,11 @@ bool TransactionManager::stopTransaction(unsigned int connector_id, const std::s
             if (!id_tag.empty())
             {
                 stop_transaction_req.idTag.value().assign(id_tag);
+            } else {
+                // Retrieve the session ID from cache when power loss occurs as it's not directly available.
+                stop_transaction_req.idTag.value().assign(connector->transaction_id_tag);
             }
+            
             stop_transaction_req.meterStop     = m_events_handler.getTxStartStopMeterValue(connector_id);
             stop_transaction_req.timestamp     = DateTime::now();
             stop_transaction_req.transactionId = connector->transaction_id;


### PR DESCRIPTION
- according to OCTT , TestCase 032_2 when the powerless occurred while the vehicle is charging and you don't have a backup power source then the charging point should send stop transaction to the back-end to close the opened session when powerless happened , but in this case the charging-point doesn't have the id-tag that corresponds to that opened session as we keep it as part of the session in the run time , so the only way to stop the session is to get this id-tag from the cache data base. 

![image](https://github.com/c-jimenez/open-ocpp/assets/100487105/38fd0fbe-a882-4f72-b445-920aac13e209)
