### PR TITLE
[localcontroller] Remove dual notification from IRtc::ISpy interface when LocalController::ChargePointProxy has been instanciated from CentralSystem::ChargePointProxy

### DIFF
--- a/src/centralsystem/chargepoint/ChargePointProxy.cpp
+++ b/src/centralsystem/chargepoint/ChargePointProxy.cpp
@@ -79,6 +79,12 @@ ChargePointProxy::ChargePointProxy(ICentralSystem&                              
 /** @brief Destructor */
 ChargePointProxy::~ChargePointProxy()
 {
+    unregisterFromRpcSpy();
+}
+
+/** @brief Unregister to the IRpc::ISpy interface messages */
+void ChargePointProxy::unregisterFromRpcSpy()
+{
     m_rpc->unregisterSpy(*this);
 }
 

--- a/src/centralsystem/chargepoint/ChargePointProxy.h
+++ b/src/centralsystem/chargepoint/ChargePointProxy.h
@@ -58,6 +58,9 @@ class ChargePointProxy : public ICentralSystem::IChargePoint, public ocpp::rpc::
     /** @brief Destructor */
     virtual ~ChargePointProxy();
 
+    /** @brief Unregister to the IRpc::ISpy interface messages */
+    void unregisterFromRpcSpy();
+
     // ICentralSystem::IChargePoint interface
 
     /** @copydoc ICentralSystem&& ICentralSystem::IChargePoint::centralSystem() */

--- a/src/localcontroller/chargepoint/ChargePointProxy.cpp
+++ b/src/localcontroller/chargepoint/ChargePointProxy.cpp
@@ -56,6 +56,9 @@ std::shared_ptr<IChargePointProxy> IChargePointProxy::createFrom(
 
         // Associate both
         centralsystem->setChargePointProxy(proxy);
+
+        // Unregister old proxy from RPC spy events
+        cs_proxy->unregisterFromRpcSpy();
     }
 
     return proxy;


### PR DESCRIPTION
[localcontroller] Remove dual notification from IRtc::ISpy interface when LocalController::ChargePointProxy has been instanciated from CentralSystem::ChargePointProxy