### PR TITLE
Added OEMRootCertificate as certificate option to the ISO15118 extension

### DIFF
--- a/examples/common/DefaultChargePointEventsHandler.h
+++ b/examples/common/DefaultChargePointEventsHandler.h
@@ -186,11 +186,13 @@ class DefaultChargePointEventsHandler : public ocpp::chargepoint::IChargePointEv
                                     bool,
                                     bool,
                                     bool,
+                                    bool,
                                     std::vector<std::tuple<GetCertificateIdUseEnumType, Certificate, std::vector<Certificate>>>&) */
     void iso15118GetInstalledCertificates(
         bool v2g_root_certificate,
         bool mo_root_certificate,
         bool v2g_certificate_chain,
+        bool oem_root_certificate,
         std::vector<std::tuple<ocpp::types::GetCertificateIdUseEnumType, ocpp::x509::Certificate, std::vector<ocpp::x509::Certificate>>>&
             certificates) override;
 

--- a/src/chargepoint/interface/IChargePointEventsHandler.h
+++ b/src/chargepoint/interface/IChargePointEventsHandler.h
@@ -324,12 +324,14 @@ class IChargePointEventsHandler
      * @param v2g_root_certificate Indicate if V2G root certificates must be listed
      * @param mo_root_certificate Indicate if MO root certificates must be listed
      * @param v2g_certificate_chain Indicate if V2G certificate chains must be listed
+     * @param oem_root_certificate Indicate if OEM root certificates must be listed
      * @param certificates Installed certificates with their type
      */
     virtual void iso15118GetInstalledCertificates(
         bool v2g_root_certificate,
         bool mo_root_certificate,
         bool v2g_certificate_chain,
+        bool oem_root_certificate,
         std::vector<std::tuple<ocpp::types::GetCertificateIdUseEnumType, ocpp::x509::Certificate, std::vector<ocpp::x509::Certificate>>>&
             certificates) = 0;
 

--- a/src/chargepoint/iso15118/Iso15118Manager.cpp
+++ b/src/chargepoint/iso15118/Iso15118Manager.cpp
@@ -339,12 +339,14 @@ void Iso15118Manager::handle(const ocpp::messages::Iso15118GetInstalledCertifica
     bool v2g_root_certificate  = false;
     bool mo_root_certificate   = false;
     bool v2g_certificate_chain = false;
+    bool oem_root_certificate  = false;
     if (request.certificateType.empty())
     {
         // All types requested
         v2g_root_certificate  = true;
         mo_root_certificate   = true;
         v2g_certificate_chain = true;
+        oem_root_certificate  = true;
     }
     else
     {
@@ -359,6 +361,9 @@ void Iso15118Manager::handle(const ocpp::messages::Iso15118GetInstalledCertifica
                 case GetCertificateIdUseEnumType::MORootCertificate:
                     mo_root_certificate = true;
                     break;
+                case GetCertificateIdUseEnumType::OEMRootCertificate:
+                    oem_root_certificate = true;
+                    break;
                 case GetCertificateIdUseEnumType::V2GCertificateChain:
                 // Intended fallthrough
                 default:
@@ -370,7 +375,7 @@ void Iso15118Manager::handle(const ocpp::messages::Iso15118GetInstalledCertifica
 
     // Notify handler to get the list of installed certificates
     std::vector<std::tuple<GetCertificateIdUseEnumType, Certificate, std::vector<Certificate>>> certificates;
-    m_events_handler.iso15118GetInstalledCertificates(v2g_root_certificate, mo_root_certificate, v2g_certificate_chain, certificates);
+    m_events_handler.iso15118GetInstalledCertificates(v2g_root_certificate, mo_root_certificate, v2g_certificate_chain, oem_root_certificate, certificates);
     if (!certificates.empty())
     {
         // Compute hashes for each certificate

--- a/src/messages/Iso15118InstallCertificate.cpp
+++ b/src/messages/Iso15118InstallCertificate.cpp
@@ -29,7 +29,8 @@ namespace types
 /** @brief Helper to convert a enum class InstallCertificateUseEnumType enum to string */
 const EnumToStringFromString<InstallCertificateUseEnumType> InstallCertificateUseEnumTypeHelper = {
     {InstallCertificateUseEnumType::MORootCertificate, "MORootCertificate"},
-    {InstallCertificateUseEnumType::V2GRootCertificate, "V2GRootCertificate"}};
+    {InstallCertificateUseEnumType::V2GRootCertificate, "V2GRootCertificate"},
+    {InstallCertificateUseEnumType::OEMRootCertificate, "OEMRootCertificate"}};
 
 /** @brief Helper to convert a enum class InstallCertificateStatusEnumType enum to string */
 const EnumToStringFromString<InstallCertificateStatusEnumType> InstallCertificateStatusEnumTypeHelper = {

--- a/src/messages/types/CertificateHashDataChainTypeConverter.cpp
+++ b/src/messages/types/CertificateHashDataChainTypeConverter.cpp
@@ -32,8 +32,8 @@ namespace types
 const EnumToStringFromString<GetCertificateIdUseEnumType> GetCertificateIdUseEnumTypeHelper = {
     {GetCertificateIdUseEnumType::MORootCertificate, "MORootCertificate"},
     {GetCertificateIdUseEnumType::V2GCertificateChain, "V2GCertificateChain"},
-    {GetCertificateIdUseEnumType::V2GRootCertificate, "V2GRootCertificate"}};
-
+    {GetCertificateIdUseEnumType::V2GRootCertificate, "V2GRootCertificate"},
+    {GetCertificateIdUseEnumType::OEMRootCertificate, "OEMRootCertificate"}};
 } // namespace types
 
 namespace messages

--- a/src/types/Enums.h
+++ b/src/types/Enums.h
@@ -1025,7 +1025,9 @@ enum class GetCertificateIdUseEnumType
                their certificates from the V2G root */
     MORootCertificate,
     /** @brief ISO 15118 V2G certificate chain (excluding the V2GRootCertificate) */
-    V2GCertificateChain
+    V2GCertificateChain,
+    /** @brief ISO 15118-20 OEM root certificates */
+    OEMRootCertificate
 };
 
 /** @brief Helper to convert a GetCertificateIdUseEnumType enum to string */
@@ -1064,7 +1066,9 @@ enum class InstallCertificateUseEnumType
                certificates */
     V2GRootCertificate,
     /** @brief Use for certificate from an eMobility Service */
-    MORootCertificate
+    MORootCertificate,
+    /** @brief Use for certificate from an OEM (Vehicle Manufacturer used for bi-directional TLS connection between Secc and EV */
+    OEMRootCertificate
 };
 
 /** @brief Helper to convert a InstallCertificateUseEnumType enum to string */

--- a/tests/deploy/main.cpp
+++ b/tests/deploy/main.cpp
@@ -923,12 +923,14 @@ class ChargePointEventsHandler : public IChargePointEventsHandler
         bool v2g_root_certificate,
         bool mo_root_certificate,
         bool v2g_certificate_chain,
+        bool oem_root_certificate,
         std::vector<std::tuple<ocpp::types::GetCertificateIdUseEnumType, ocpp::x509::Certificate, std::vector<ocpp::x509::Certificate>>>&
             certificates) override
     {
         (void)v2g_root_certificate;
         (void)mo_root_certificate;
         (void)v2g_certificate_chain;
+        (void)oem_root_certificate;
         (void)certificates;
     }
 

--- a/tests/stubs/ChargePointEventsHandlerStub.cpp
+++ b/tests/stubs/ChargePointEventsHandlerStub.cpp
@@ -339,18 +339,21 @@ ocpp::types::DeleteCertificateStatusEnumType ChargePointEventsHandlerStub::iso15
                                     bool,
                                     bool,
                                     bool,
+                                    bool,
                                     std::vector<std::tuple<GetCertificateIdUseEnumType, Certificate, std::vector<Certificate>>>&) */
 void ChargePointEventsHandlerStub::iso15118GetInstalledCertificates(
     bool v2g_root_certificate,
     bool mo_root_certificate,
     bool v2g_certificate_chain,
+    bool oem_root_certificate,
     std::vector<std::tuple<ocpp::types::GetCertificateIdUseEnumType, ocpp::x509::Certificate, std::vector<ocpp::x509::Certificate>>>&
         certificates)
 {
     (void)certificates;
     m_calls["iso15118GetInstalledCertificates"] = {{"v2g_root_certificate", std::to_string(v2g_root_certificate)},
                                                    {"mo_root_certificate", std::to_string(mo_root_certificate)},
-                                                   {"v2g_certificate_chain", std::to_string(v2g_certificate_chain)}};
+                                                   {"v2g_certificate_chain", std::to_string(v2g_certificate_chain)},
+                                                   {"oem_root_certificate", std::to_string(oem_root_certificate)}};
 }
 
 /** @copydoc ocpp::types::InstallCertificateStatusEnumType IChargePointEventsHandler::iso15118CertificateReceived(

--- a/tests/stubs/ChargePointEventsHandlerStub.h
+++ b/tests/stubs/ChargePointEventsHandlerStub.h
@@ -173,11 +173,13 @@ class ChargePointEventsHandlerStub : public ocpp::chargepoint::IChargePointEvent
                                     bool,
                                     bool,
                                     bool,
+                                    bool,
                                     std::vector<std::tuple<GetCertificateIdUseEnumType, Certificate, std::vector<Certificate>>>&) */
     void iso15118GetInstalledCertificates(
         bool v2g_root_certificate,
         bool mo_root_certificate,
         bool v2g_certificate_chain,
+        bool oem_root_certificate,
         std::vector<std::tuple<ocpp::types::GetCertificateIdUseEnumType, ocpp::x509::Certificate, std::vector<ocpp::x509::Certificate>>>&
             certificates) override;
 


### PR DESCRIPTION
We are testing mutual TLS connections with EV's. This change would allow us to install the OEM root certificate neatly through an ocpp backend that also provides this option. In the future we would obviously like to do this with OCPP2.1, but for now I think this is a nice solution. 
