### PR TITLE
[websockets] Add server name parameter to allow the use of an IP address for the connection URL (DNS resolution done beforehand) when using a TLS link (server name is used for certificate hostname check)

### DIFF
--- a/3rdparty/libwebsockets/lib/core-net/client/connect4.c
+++ b/3rdparty/libwebsockets/lib/core-net/client/connect4.c
@@ -57,7 +57,7 @@ lws_client_connect_4_established(struct lws *wsi, struct lws *wsi_piggyback,
 	if (wsi->a.vhost->http.http_proxy_port) {
 		const char *cpa;
 
-		cpa = lws_wsi_client_stash_item(wsi, CIS_ADDRESS,
+		cpa = lws_wsi_client_stash_item(wsi, CIS_HOST,
 						_WSI_TOKEN_CLIENT_PEER_ADDRESS);
 		if (!cpa)
 			goto failed;

--- a/src/websockets/IWebsocketClient.h
+++ b/src/websockets/IWebsocketClient.h
@@ -149,6 +149,8 @@ class IWebsocketClient
         /** @brief Skip server name check in certificates for TLS connections
          *         (Warning : enabling this feature is not recommended in production) */
         bool skip_server_name_check;
+        /** @brief Server name (used for server certificate check) */
+        std::string server_name;
     };
 };
 

--- a/src/websockets/libwebsockets/LibWebsocketClient.cpp
+++ b/src/websockets/libwebsockets/LibWebsocketClient.cpp
@@ -358,8 +358,15 @@ void LibWebsocketClient::connectCallback(struct lws_sorted_usec_list* sul) noexc
     i.context = client->m_context;
     i.address = client->m_url.address().c_str();
     i.path    = client->m_url.path().c_str();
-    i.host    = i.address;
-    i.origin  = i.address;
+    if (client->m_credentials.server_name.empty())
+    {
+        i.host = i.address;
+    }
+    else
+    {
+        i.host = client->m_credentials.server_name.c_str();
+    }
+    i.origin = i.address;
     if (client->m_url.protocol() == "wss")
     {
         i.ssl_connection = LCCSCF_USE_SSL;

--- a/src/websockets/libwebsockets/LibWebsocketClientPool.cpp
+++ b/src/websockets/libwebsockets/LibWebsocketClientPool.cpp
@@ -147,7 +147,7 @@ void LibWebsocketClientPool::process()
 
     // Dummy vhost to handle context related events
     struct lws_protocols             protocols[] = {{"LibWebsocketClientPool", &LibWebsocketClientPool::eventCallback, 0, 0, 0, this, 0},
-                                                    LWS_PROTOCOL_LIST_TERM};
+                                        LWS_PROTOCOL_LIST_TERM};
     struct lws_context_creation_info vhost_info;
     memset(&vhost_info, 0, sizeof(vhost_info));
     vhost_info.protocols = protocols;
@@ -537,8 +537,15 @@ void LibWebsocketClientPool::Client::connectCallback(struct lws_sorted_usec_list
                 connect_info.vhost   = client->m_vhost;
                 connect_info.address = client->m_url.address().c_str();
                 connect_info.path    = client->m_url.path().c_str();
-                connect_info.host    = connect_info.address;
-                connect_info.origin  = connect_info.address;
+                if (client->m_credentials.server_name.empty())
+                {
+                    connect_info.host = connect_info.address;
+                }
+                else
+                {
+                    connect_info.host = client->m_credentials.server_name.c_str();
+                }
+                connect_info.origin = connect_info.address;
                 if (client->m_url.protocol() == "wss")
                 {
                     connect_info.ssl_connection = LCCSCF_USE_SSL;


### PR DESCRIPTION
[websockets] Add server name parameter to allow the use of an IP address for the connection URL (DNS resolution done beforehand) when using a TLS link (server name is used for certificate hostname check)