### PR TITLE
If the status of Connecter is not Charging before StopTransaction

### DIFF
--- a/src/chargepoint/metervalues/MeterValuesManager.cpp
+++ b/src/chargepoint/metervalues/MeterValuesManager.cpp
@@ -365,7 +365,7 @@ void MeterValuesManager::processSampled(unsigned int connector_id)
 
                 // Get connector
                 Connector* connector = m_connectors.getConnector(connector_id);
-                if (connector)
+                if (connector && connector->status == ocpp::types::ChargePointStatus::Charging)
                 {
                     // Send sampled meter values
                     sendMeterValues(connector->id, measurands, ReadingContext::SamplePeriodic, connector->transaction_id);


### PR DESCRIPTION
If the status of the Connecter is not Charging before StopTransaction, maybe skip sendMeterValues in the function processSampled;   such as SuspendedEV