### PR TITLE
[cmake] Add option to install RapidJSON headers

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,11 +1,13 @@
 
 # Rapidjson is an header only library
-add_library(rapidjson INTERFACE)
-if("${CMAKE_CXX_STANDARD}" GREATER_EQUAL 17)
-    # use of std::iterator is deprecated since c++ 17
-    target_compile_definitions(rapidjson INTERFACE -DRAPIDJSON_NOMEMBERITERATORCLASS=1)
+if(${INSTALL_RAPID_JSON})
+    add_library(rapidjson INTERFACE)
+    if("${CMAKE_CXX_STANDARD}" GREATER_EQUAL 17)
+        # use of std::iterator is deprecated since c++ 17
+        target_compile_definitions(rapidjson INTERFACE -DRAPIDJSON_NOMEMBERITERATORCLASS=1)
+    endif()
+    target_include_directories(rapidjson INTERFACE rapidjson/include)
 endif()
-target_include_directories(rapidjson INTERFACE rapidjson/include)
 
 # Doctest is an header only on library
 if(${INSTALL_DOCTEST})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,15 +132,17 @@ install(TARGETS ${OPEN_OCPP_SHARED_TARGET} ${OPEN_OCPP_STATIC_TARGET}
 install(FILES ${PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp)
 install(FILES ${OCPP_SCHEMAS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/schemas)
 
-file(GLOB RAPIDJSON_HEADERS
-     LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include/rapidjson/*.h")
-file(GLOB RAPIDJSON_INTERNAL_HEADERS
-     LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include/rapidjson/internal/*.h")
-file(GLOB RAPIDJSON_ERROR_HEADERS
-     LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include/rapidjson/error/*.h")
-install(FILES ${RAPIDJSON_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/rapidjson)
-install(FILES ${RAPIDJSON_INTERNAL_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/rapidjson/internal)
-install(FILES ${RAPIDJSON_ERROR_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/rapidjson/error)
+if(${INSTALL_RAPID_JSON})
+    file(GLOB RAPIDJSON_HEADERS
+         LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include/rapidjson/*.h")
+    file(GLOB RAPIDJSON_INTERNAL_HEADERS
+         LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include/rapidjson/internal/*.h")
+    file(GLOB RAPIDJSON_ERROR_HEADERS
+         LIST_DIRECTORIES false RELATIVE ${CMAKE_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/3rdparty/rapidjson/include/rapidjson/error/*.h")
+    install(FILES ${RAPIDJSON_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/rapidjson)
+    install(FILES ${RAPIDJSON_INTERNAL_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/rapidjson/internal)
+    install(FILES ${RAPIDJSON_ERROR_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openocpp/rapidjson/error)
+endif()
 
 # Generate pkgconfig files
 set(PKG_CONFIG_LIBDIR       "\${prefix}/lib")

--- a/CMakeLists_Options.txt
+++ b/CMakeLists_Options.txt
@@ -35,6 +35,9 @@ option(BUILD_SQLITE                 "Build sqlite3 library"                     
 # Install the Doctest header
 option(INSTALL_DOCTEST              "Install doctest headers"                                               ON)
 
+# Define Install Rapid Json headers
+option(INSTALL_RAPID_JSON           "Install headers of rapidjson"                                          ON)
+
 # Use only the CrtAllocator in Rapidjson, not the MemoryPoolAllocator
 option(USE_CRT_ALLOC_FOR_RAPIDJSON  "Use the CrtAllocator for Rapidjson instead of the MemoryPoolAllocator" OFF)
 if(USE_CRT_ALLOC_FOR_RAPIDJSON)


### PR DESCRIPTION
When the library is already provided in the build system, it is not necessary to install it. Example: Yocto Project