### PR TITLE
[chargepoint-transaction] Update startTransaction method to include t…

### DIFF
--- a/examples/iso15118_chargepoint/main.cpp
+++ b/examples/iso15118_chargepoint/main.cpp
@@ -195,6 +195,7 @@ int main(int argc, char* argv[])
                 AuthorizationStatus status = charge_point->iso15118Authorize(ev_certificate, token_id, cert_hash_data, cert_status);
                 if (status == AuthorizationStatus::Accepted)
                 {
+                    int transaction_id = 0;
                     std::cout << "Token id and certificate authorized" << std::endl;
 
                     // Preparing state
@@ -202,10 +203,10 @@ int main(int argc, char* argv[])
                     std::this_thread::sleep_for(std::chrono::seconds(1u));
 
                     // Try to start charging session
-                    status = charge_point->startTransaction(connector_id, token_id);
+                    status = charge_point->startTransaction(connector_id, token_id, transaction_id);
                     if (status == AuthorizationStatus::Accepted)
                     {
-                        std::cout << "Transaction authorized, start charging" << std::endl;
+                        std::cout << "Transaction " << transaction_id << " authorized, start charging" << std::endl;
 
                         // Charging state
                         charge_point->statusNotification(connector_id, ChargePointStatus::Charging);

--- a/examples/quick_start_chargepoint/main.cpp
+++ b/examples/quick_start_chargepoint/main.cpp
@@ -144,6 +144,7 @@ int main(int argc, char* argv[])
             {
                 // Ask for authorization on a tag
                 std::string         parent_id;
+                int transaction_id = 0;
                 AuthorizationStatus status = charge_point->authorize(connector_id, id_tag, parent_id);
                 if (status == AuthorizationStatus::Accepted)
                 {
@@ -154,10 +155,10 @@ int main(int argc, char* argv[])
                     std::this_thread::sleep_for(std::chrono::seconds(1u));
 
                     // Try to start charging session
-                    status = charge_point->startTransaction(connector_id, id_tag);
+                    status = charge_point->startTransaction(connector_id, id_tag, transaction_id);
                     if (status == AuthorizationStatus::Accepted)
                     {
-                        std::cout << "Transaction authorized, start charging" << std::endl;
+                        std::cout << "Transaction " << transaction_id << " authorized, start charging" << std::endl;
 
                         // Charging state
                         charge_point->statusNotification(connector_id, ChargePointStatus::Charging);

--- a/examples/remote_chargepoint/main.cpp
+++ b/examples/remote_chargepoint/main.cpp
@@ -218,10 +218,11 @@ int main(int argc, char* argv[])
             if (restore || !config.ocppConfig().authorizeRemoteTxRequests() ||
                 (charge_point->authorize(connector_id, id_tag, parent_id) == AuthorizationStatus::Accepted))
             {
+                int transaction_id = 0;
                 // Start transaction
-                if (restore || charge_point->startTransaction(connector_id, id_tag) == AuthorizationStatus::Accepted)
+                if (restore || charge_point->startTransaction(connector_id, id_tag, transaction_id) == AuthorizationStatus::Accepted)
                 {
-                    // Notify suspent
+                    // Notify suspended
                     if (!restore)
                     {
                         charge_point->statusNotification(connector_id, ChargePointStatus::SuspendedEVSE);

--- a/src/chargepoint/ChargePoint.cpp
+++ b/src/chargepoint/ChargePoint.cpp
@@ -543,8 +543,8 @@ ocpp::types::AuthorizationStatus ChargePoint::authorize(unsigned int connector_i
     return ret;
 }
 
-/** @copydoc ocpp::types::AuthorizationStatus IChargePoint::startTransaction(unsigned int, const std::string&) */
-ocpp::types::AuthorizationStatus ChargePoint::startTransaction(unsigned int connector_id, const std::string& id_tag)
+/** @copydoc ocpp::types::AuthorizationStatus IChargePoint::startTransaction(unsigned int, const std::string&, int&) */
+ocpp::types::AuthorizationStatus ChargePoint::startTransaction(unsigned int connector_id, const std::string& id_tag, int& transaction_id)
 {
     AuthorizationStatus ret = AuthorizationStatus::Invalid;
 
@@ -552,7 +552,7 @@ ocpp::types::AuthorizationStatus ChargePoint::startTransaction(unsigned int conn
     {
         if (m_status_manager->getRegistrationStatus() == RegistrationStatus::Accepted)
         {
-            ret = m_transaction_manager->startTransaction(connector_id, id_tag);
+            ret = m_transaction_manager->startTransaction(connector_id, id_tag, transaction_id);
         }
         else
         {

--- a/src/chargepoint/ChargePoint.h
+++ b/src/chargepoint/ChargePoint.h
@@ -127,8 +127,8 @@ class ChargePoint : public IChargePoint,
     /** @copydoc ocpp::types::AuthorizationStatus IChargePoint::authorize(unsigned int, const std::string&, std::string&) */
     ocpp::types::AuthorizationStatus authorize(unsigned int connector_id, const std::string& id_tag, std::string& parent_id) override;
 
-    /** @copydoc ocpp::types::AuthorizationStatus IChargePoint::startTransaction(unsigned int, const std::string&) */
-    ocpp::types::AuthorizationStatus startTransaction(unsigned int connector_id, const std::string& id_tag) override;
+    /** @copydoc ocpp::types::AuthorizationStatus IChargePoint::startTransaction(unsigned int, const std::string&, int&) */
+    ocpp::types::AuthorizationStatus startTransaction(unsigned int connector_id, const std::string& id_tag, int& transaction_id) override;
 
     /** @copydoc bool IChargePoint::stopTransaction(unsigned int, const std::string&, ocpp::types::Reason) */
     bool stopTransaction(unsigned int connector_id, const std::string& id_tag, ocpp::types::Reason reason) override;

--- a/src/chargepoint/interface/IChargePoint.h
+++ b/src/chargepoint/interface/IChargePoint.h
@@ -158,9 +158,10 @@ class IChargePoint
      * @brief Start a transaction
      * @param connector_id Id of the connector
      * @param id_tag Id of the user
+     * @param transaction_id Id of the transaction
      * @return ocpp::types::AuthorizationStatus (see AuthorizationStatus enum)
      */
-    virtual ocpp::types::AuthorizationStatus startTransaction(unsigned int connector_id, const std::string& id_tag) = 0;
+    virtual ocpp::types::AuthorizationStatus startTransaction(unsigned int connector_id, const std::string& id_tag, int& transaction_id) = 0;
 
     /**
      * @brief Stop a transaction

--- a/src/chargepoint/transaction/TransactionManager.cpp
+++ b/src/chargepoint/transaction/TransactionManager.cpp
@@ -75,7 +75,7 @@ TransactionManager::TransactionManager(ocpp::config::IOcppConfig&               
 TransactionManager::~TransactionManager() { }
 
 /** @brief Start a transaction */
-ocpp::types::AuthorizationStatus TransactionManager::startTransaction(unsigned int connector_id, const std::string& id_tag)
+ocpp::types::AuthorizationStatus TransactionManager::startTransaction(unsigned int connector_id, const std::string& id_tag, int& transaction_id)
 {
     AuthorizationStatus ret = AuthorizationStatus::Invalid;
 
@@ -169,6 +169,7 @@ ocpp::types::AuthorizationStatus TransactionManager::startTransaction(unsigned i
                         connector->transaction_parent_id_tag = start_transaction_conf.idTagInfo.parentIdTag.value().str();
                         m_connectors.saveConnector(connector->id);
                     }
+                    transaction_id = connector->transaction_id;
 
                     // Assign pending charging profiles to the transaction
                     m_smart_charging_manager.assignPendingTxProfiles(connector_id, connector->transaction_id);

--- a/src/chargepoint/transaction/TransactionManager.h
+++ b/src/chargepoint/transaction/TransactionManager.h
@@ -78,9 +78,10 @@ class TransactionManager
      * @brief Start a transaction
      * @param connector_id Id of the connector
      * @param id_tag Id of the user
+     * @param transaction_id Id of the transaction
      * @return ocpp::types::AuthorizationStatus (see AuthorizationStatus enum)
      */
-    ocpp::types::AuthorizationStatus startTransaction(unsigned int connector_id, const std::string& id_tag);
+    ocpp::types::AuthorizationStatus startTransaction(unsigned int connector_id, const std::string& id_tag, int& transaction_id);
 
     /**
      * @brief Stop a transaction


### PR DESCRIPTION
The user application may need the transaction id for a metrological unit of measurement even if in offline -1 is returned for example.