### PR TITLE
[types-enums] Fix typo in the description of Invalid

### DIFF
--- a/src/types/Enums.h
+++ b/src/types/Enums.h
@@ -172,7 +172,7 @@ enum class AuthorizationStatus
     Blocked,
     /** @brief Identifier has expired. Not allowed for charging */
     Expired,
-    /** @brief Identifier has expired. Not allowed for charging */
+    /** @brief Identifier is unknown. Not allowed for charging */
     Invalid,
     /** @brief Identifier is already involved in another transaction and multiple transactions are not allowed. (Only relevant for a
                StartTransaction.req */


### PR DESCRIPTION
Fix typo in the description of Invalid in AuthorizationStatus

The description is based on the OCPP 1.6 edition 2 document.