### PR TITLE
[ChargePointEventsHandler] Event when the connection URL detected

### DIFF
--- a/examples/common/DefaultChargePointEventsHandler.cpp
+++ b/examples/common/DefaultChargePointEventsHandler.cpp
@@ -61,6 +61,12 @@ DefaultChargePointEventsHandler::DefaultChargePointEventsHandler(ChargePointDemo
 /** @brief Destructor */
 DefaultChargePointEventsHandler::~DefaultChargePointEventsHandler() { }
 
+/** @copydoc void IChargePointEventsHandler::connectionUrlChanged(std::string const&) */
+void DefaultChargePointEventsHandler::connectionUrlChanged(std::string const& url)
+{
+    cout << "Connection url changed to : " << url << endl;
+}
+
 /** @copydoc void IChargePointEventsHandler::connectionStateChanged(ocpp::types::RegistrationStatus) */
 void DefaultChargePointEventsHandler::connectionFailed(ocpp::types::RegistrationStatus status)
 {

--- a/examples/common/DefaultChargePointEventsHandler.h
+++ b/examples/common/DefaultChargePointEventsHandler.h
@@ -48,6 +48,9 @@ class DefaultChargePointEventsHandler : public ocpp::chargepoint::IChargePointEv
 
     // IChargePointEventsHandler interface
 
+    /** @copydoc void IChargePointEventsHandler::connectionUrlChanged(std::string const&) */
+    void connectionUrlChanged(std::string const& url) override;
+
     /** @copydoc void IChargePointEventsHandler::connectionStateChanged(ocpp::types::RegistrationStatus) */
     void connectionFailed(ocpp::types::RegistrationStatus status) override;
 

--- a/src/chargepoint/ChargePoint.cpp
+++ b/src/chargepoint/ChargePoint.cpp
@@ -1155,6 +1155,9 @@ bool ChargePoint::doConnect()
 
         // Reset registration status
         m_internal_config.setKey(LAST_REGISTRATION_STATUS_KEY, RegistrationStatusHelper.toString(RegistrationStatus::Rejected));
+        
+        // Notify that the connection URL has changed
+        m_events_handler.connectionUrlChanged(connection_url);
 
         LOG_INFO << "Connection URL has changed, reset registration status";
     }

--- a/src/chargepoint/interface/IChargePointEventsHandler.h
+++ b/src/chargepoint/interface/IChargePointEventsHandler.h
@@ -40,6 +40,12 @@ class IChargePointEventsHandler
     virtual ~IChargePointEventsHandler() { }
 
     /**
+     * @brief Called when the connection URL has changed
+     * @param url New connection URL
+     */
+    virtual void connectionUrlChanged(std::string const& url) = 0;
+
+    /**
      * @brief Called when the first attempt to connect to the central system has failed
      * @param status Previous registration status (if Accepted, some offline operations are allowed)
      */

--- a/tests/stubs/ChargePointEventsHandlerStub.cpp
+++ b/tests/stubs/ChargePointEventsHandlerStub.cpp
@@ -38,6 +38,12 @@ ChargePointEventsHandlerStub::ChargePointEventsHandlerStub()
 /** @brief Destructor */
 ChargePointEventsHandlerStub::~ChargePointEventsHandlerStub() { }
 
+/** @copydoc void IChargePointEventsHandler::connectionUrlChanged(std::string const&) */
+void ChargePointEventsHandlerStub::connectionUrlChanged(std::string const& url)
+{
+    m_calls["connectionUrlChanged"] = {{"url", url}};
+}
+
 /** @copydoc void IChargePointEventsHandler::connectionStateChanged(ocpp::types::RegistrationStatus) */
 void ChargePointEventsHandlerStub::connectionFailed(ocpp::types::RegistrationStatus status)
 {

--- a/tests/stubs/ChargePointEventsHandlerStub.h
+++ b/tests/stubs/ChargePointEventsHandlerStub.h
@@ -35,6 +35,9 @@ class ChargePointEventsHandlerStub : public ocpp::chargepoint::IChargePointEvent
 
     // IChargePointEventsHandler interface
 
+    /** @copydoc void IChargePointEventsHandler::connectionUrlChanged(std::string const&) */
+    void connectionUrlChanged(std::string const& url) override;
+
     /** @copydoc void IChargePointEventsHandler::connectionStateChanged(ocpp::types::RegistrationStatus) */
     void connectionFailed(ocpp::types::RegistrationStatus status) override;
 


### PR DESCRIPTION
This is useful to clear custom OCPP keys, when the connection URL is changed.