### PR TITLE
[json-JsonValidator] Clang - Add missing include <string>

### DIFF
--- a/src/tools/json/JsonValidator.h
+++ b/src/tools/json/JsonValidator.h
@@ -22,6 +22,7 @@ along with OpenOCPP. If not, see <http://www.gnu.org/licenses/>.
 #include "json.h"
 
 #include <memory>
+#include <string>
 
 namespace ocpp
 {


### PR DESCRIPTION
Here is the PR, to solve one the error mentioned in my issue #250.