### PR TITLE
[examples-EventsHandler] Clang - Fix WEXITSTATUS usage by passing a variable

### DIFF
--- a/examples/common/DefaultCentralSystemEventsHandler.cpp
+++ b/examples/common/DefaultCentralSystemEventsHandler.cpp
@@ -423,7 +423,8 @@ bool DefaultCentralSystemEventsHandler::ChargePointRequestHandler::signCertifica
                 std::stringstream sign_cert_cmd_line;
                 sign_cert_cmd_line << "openssl x509 -req -sha256 -days 3650 -in " << csr_filename << " -CA " << ca_cert_path << " -CAkey "
                                    << ca_cert_key_path << " -CAcreateserial -out " << certificate_filename;
-                int err = WEXITSTATUS(system(sign_cert_cmd_line.str().c_str()));
+                int system_ret = system(sign_cert_cmd_line.str().c_str());
+                int err        = WEXITSTATUS(system_ret);
                 cout << "Command line : " << sign_cert_cmd_line.str() << " => " << err << endl;
 
                 // Check if the certificate has been generated
@@ -433,7 +434,8 @@ bool DefaultCentralSystemEventsHandler::ChargePointRequestHandler::signCertifica
                     std::string       bundle_filename = certificate_filename + ".bundle";
                     std::stringstream generate_bundle_cmd_line;
                     generate_bundle_cmd_line << "cat " << certificate_filename << " " << ca_cert_path << " > " << bundle_filename;
-                    err = WEXITSTATUS(system(generate_bundle_cmd_line.str().c_str()));
+                    int bundle_ret = system(generate_bundle_cmd_line.str().c_str());
+                    err            = WEXITSTATUS(bundle_ret);
                     cout << "Command line : " << generate_bundle_cmd_line.str() << " => " << err << endl;
                     if (std::filesystem::exists(bundle_filename))
                     {
@@ -611,7 +613,8 @@ bool DefaultCentralSystemEventsHandler::ChargePointRequestHandler::iso15118SignC
             std::stringstream sign_cert_cmd_line;
             sign_cert_cmd_line << "openssl x509 -req -sha256 -days 3650 -in " << csr_filename << " -CA " << ca_cert_path << " -CAkey "
                                << ca_cert_key_path << " -CAcreateserial -out " << certificate_filename;
-            int err = WEXITSTATUS(system(sign_cert_cmd_line.str().c_str()));
+            int system_ret = system(sign_cert_cmd_line.str().c_str());
+            int err        = WEXITSTATUS(system_ret);
             cout << "Command line : " << sign_cert_cmd_line.str() << " => " << err << endl;
 
             // Check if the certificate has been generated
@@ -621,7 +624,8 @@ bool DefaultCentralSystemEventsHandler::ChargePointRequestHandler::iso15118SignC
                 std::string       bundle_filename = certificate_filename + ".bundle";
                 std::stringstream generate_bundle_cmd_line;
                 generate_bundle_cmd_line << "cat " << certificate_filename << " " << ca_cert_path << " > " << bundle_filename;
-                err = WEXITSTATUS(system(generate_bundle_cmd_line.str().c_str()));
+                int bundle_ret = system(generate_bundle_cmd_line.str().c_str());
+                err            = WEXITSTATUS(bundle_ret);
                 cout << "Command line : " << generate_bundle_cmd_line.str() << " => " << err << endl;
                 if (std::filesystem::exists(bundle_filename))
                 {

--- a/examples/common/DefaultChargePointEventsHandler.cpp
+++ b/examples/common/DefaultChargePointEventsHandler.cpp
@@ -239,7 +239,8 @@ std::string DefaultChargePointEventsHandler::getDiagnostics(const ocpp::types::O
 
     std::stringstream ss;
     ss << "zip " << diag_file << " " << m_config.stackConfig().databasePath();
-    int err = WEXITSTATUS(system(ss.str().c_str()));
+    int sys_ret = system(ss.str().c_str());
+    int err     = WEXITSTATUS(sys_ret);
     cout << "Command line : " << ss.str() << " => " << err << endl;
 
     return diag_file;
@@ -295,7 +296,8 @@ bool DefaultChargePointEventsHandler::uploadFile(const std::string& file, const 
     {
         std::stringstream ss;
         ss << "curl --silent " << params << " -T " << file << " " << connection_url;
-        int err = WEXITSTATUS(system(ss.str().c_str()));
+        int sys_ret = system(ss.str().c_str());
+        int err     = WEXITSTATUS(sys_ret);
         cout << "Command line : " << ss.str() << endl;
         ret = (err == 0);
     }
@@ -339,7 +341,8 @@ bool DefaultChargePointEventsHandler::downloadFile(const std::string& url, const
     {
         std::stringstream ss;
         ss << "curl --silent " << params << " -o " << file << " " << connection_url;
-        int err = WEXITSTATUS(system(ss.str().c_str()));
+        int sys_ret = system(ss.str().c_str());
+        int err     = WEXITSTATUS(sys_ret);
         cout << "Command line : " << ss.str() << endl;
         ret = (err == 0);
     }
@@ -627,7 +630,8 @@ std::string DefaultChargePointEventsHandler::getLog(ocpp::types::LogEnumType    
 
         std::stringstream ss;
         ss << "zip " << log_file << " " << m_config.stackConfig().databasePath();
-        int err = WEXITSTATUS(system(ss.str().c_str()));
+        int sys_ret = system(ss.str().c_str());
+        int err     = WEXITSTATUS(sys_ret);
         cout << "Command line : " << ss.str() << " => " << err << endl;
     }
 


### PR DESCRIPTION
Passing the result of the system command directly to WEXITSTATUS treats it as a temporary value, which may lead to invalid memory access. By storing the result in a variable before calling the macro, we ensure that the variable's address is valid, preventing errors or warnings. Clang especially reports it as an error, preventing compilation.

Partially solves issue #250 