### PR TITLE
feat(event-handler): Add const parameter `url` to updateFirmwareRequested

### DIFF
--- a/examples/ocpp16/common/DefaultChargePointEventsHandler.cpp
+++ b/examples/ocpp16/common/DefaultChargePointEventsHandler.cpp
@@ -248,10 +248,10 @@ std::string DefaultChargePointEventsHandler::getDiagnostics(const ocpp::types::O
     return diag_file;
 }
 
-/** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested() */
-std::string DefaultChargePointEventsHandler::updateFirmwareRequested()
+/** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested(const std::string&) */
+std::string DefaultChargePointEventsHandler::updateFirmwareRequested(const std::string& url)
 {
-    cout << "Firmware update requested" << endl;
+    cout << "Firmware update requested from: " << url << endl;
     return "/tmp/firmware.tar.gz";
 }
 

--- a/examples/ocpp16/common/DefaultChargePointEventsHandler.h
+++ b/examples/ocpp16/common/DefaultChargePointEventsHandler.h
@@ -115,8 +115,8 @@ class DefaultChargePointEventsHandler : public ocpp::chargepoint::IChargePointEv
     std::string getDiagnostics(const ocpp::types::Optional<ocpp::types::DateTime>& start_time,
                                const ocpp::types::Optional<ocpp::types::DateTime>& stop_time) override;
 
-    /** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested() */
-    std::string updateFirmwareRequested() override;
+    /** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested(const std::string&) */
+    std::string updateFirmwareRequested(const std::string& url) override;
 
     /** @copydoc void IChargePointEventsHandler::installFirmware() */
     void installFirmware(const std::string& firmware_file) override;

--- a/src/ocpp16/chargepoint/interface/IChargePointEventsHandler.h
+++ b/src/ocpp16/chargepoint/interface/IChargePointEventsHandler.h
@@ -184,9 +184,10 @@ class IChargePointEventsHandler
 
     /**
      * @brief Called on an update firmware request
+     * @param url URL from where to download the file
      * @return Path where to download the firmware
      */
-    virtual std::string updateFirmwareRequested() = 0;
+    virtual std::string updateFirmwareRequested(const std::string& url) = 0;
 
     /**
      * @brief Called when a firmware is ready to be installed

--- a/src/ocpp16/chargepoint/maintenance/MaintenanceManager.cpp
+++ b/src/ocpp16/chargepoint/maintenance/MaintenanceManager.cpp
@@ -655,7 +655,7 @@ void MaintenanceManager::processUpdateFirmware(std::string                      
     }
 
     // Notify start of download
-    std::string local_firmware_file = m_events_handler.updateFirmwareRequested();
+    std::string local_firmware_file = m_events_handler.updateFirmwareRequested(location);
     m_firmware_status               = FirmwareStatus::Downloading;
     sendFirmwareStatusNotification();
 
@@ -857,7 +857,7 @@ void MaintenanceManager::processSignedUpdateFirmware(std::string                
     }
 
     // Notify start of download
-    std::string local_firmware_file = m_events_handler.updateFirmwareRequested();
+    std::string local_firmware_file = m_events_handler.updateFirmwareRequested(location);
     m_signed_firmware_status        = FirmwareStatusEnumType::Downloading;
     sendSignedFirmwareStatusNotification();
 

--- a/tests/deploy/main.cpp
+++ b/tests/deploy/main.cpp
@@ -717,9 +717,10 @@ class ChargePointEventsHandler : public IChargePointEventsHandler
 
     /**
      * @brief Called on an update firmware request
+     * @param url URL from where to download the file
      * @return Path where to download the firmware
      */
-    std::string updateFirmwareRequested() override { return ""; }
+    std::string updateFirmwareRequested(const std::string& url) override { return ""; }
 
     /**
      * @brief Called when a firmware is ready to be installed

--- a/tests/stubs/ChargePointEventsHandlerStub.cpp
+++ b/tests/stubs/ChargePointEventsHandlerStub.cpp
@@ -198,10 +198,10 @@ std::string ChargePointEventsHandlerStub::getDiagnostics(const ocpp::types::Opti
     return m_diag_file;
 }
 
-/** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested() */
-std::string ChargePointEventsHandlerStub::updateFirmwareRequested()
+/** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested(const std::string&) */
+std::string ChargePointEventsHandlerStub::updateFirmwareRequested(const std::string& url)
 {
-    m_calls["updateFirmwareRequested"] = {{}};
+    m_calls["updateFirmwareRequested"] = {{"url", url}};
     return m_diag_file;
 }
 

--- a/tests/stubs/ChargePointEventsHandlerStub.h
+++ b/tests/stubs/ChargePointEventsHandlerStub.h
@@ -102,8 +102,8 @@ class ChargePointEventsHandlerStub : public ocpp::chargepoint::IChargePointEvent
     std::string getDiagnostics(const ocpp::types::Optional<ocpp::types::DateTime>& start_time,
                                const ocpp::types::Optional<ocpp::types::DateTime>& stop_time) override;
 
-    /** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested() */
-    std::string updateFirmwareRequested() override;
+    /** @copydoc std::string IChargePointEventsHandler::updateFirmwareRequested(const std::string&) */
+    std::string updateFirmwareRequested(const std::string& url) override;
 
     /** @copydoc void IChargePointEventsHandler::installFirmware() */
     void installFirmware(const std::string& firmware_file) override;


### PR DESCRIPTION
The filename could be parsed from the URL to be used during the download and installation process.
By passing the URL to the `updateFirmwareRequested` function, it can be parsed and used later. This allows the system to handle any firmware file name dynamically and process it accordingly.