### PR TITLE
Fix JSON parsing and validation in processReceivedData

### DIFF
--- a/src/rpc/RpcBase.cpp
+++ b/src/rpc/RpcBase.cpp
@@ -312,6 +312,8 @@ void RpcBase::processReceivedData(const void* data, size_t size)
     }
     catch (const std::exception&)
     {
+        sendCallError("", RPC_ERROR_PROTOCOL, "");
+        return;
     }
     if (valid && rpc_frame.IsArray() && (rpc_frame.Size() >= 3))
     {


### PR DESCRIPTION
Ensured the RPC frame is a valid JSON array with the expected structure before processing.